### PR TITLE
v1.3 - deprecate AdjustableButtonConfig and merge into ButtonConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Here are the high-level features of the AceButton library:
 * thoroughly unit tested using [AUnit](https://github.com/bxparks/AUnit)
 * properly handles reboots while the button is pressed
 * properly handles orphaned clicks, to prevent spurious double-clicks
-* only 17-20 microseconds (on 16MHz ATmega328P) per polling call to `AceButton::check()`
+* only 13-15 microseconds (on 16MHz ATmega328P) per polling call to `AceButton::check()`
 * can be instrumented to extract profiling numbers
 * tested on Arduino AVR (UNO, Nano, etc), Teensy ARM (LC
   and 3.2), ESP8266 and ESP32 platforms
@@ -100,7 +100,7 @@ you are seriously optimizing for program size or CPU cycles, you will probably
 want to write everything yourself from scratch.
 
 That said, the [examples/AutoBenchmark](examples/AutoBenchmark) program
-shows that `AceButton::check()` takes between 17-20 microseconds on a 16MHz
+shows that `AceButton::check()` takes between 13-15 microseconds on a 16MHz
 ATmega328P chip on average. Hopefully that is fast enough for the vast
 majority of people.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Here is a simple program (see `examples/HelloButton.ino`) which controls
 the builtin LED on the Arduino board using a momentary button connected
 to PIN 2.
 
-```
+```C++
 #include <AceButton.h>
 using namespace ace_button;
 
@@ -233,14 +233,14 @@ To prevent name clashes with other libraries that the calling code may use, all
 classes are defined in the `ace_button` namespace. To use the code without
 prepending the `ace_button::` prefix, use the `using` directive:
 
-```
+```C++
 #include <AceButton.h>
 using namespace ace_button;
 ```
 
 If you are dependent on just `AceButton`, the following might be sufficient:
 
-```
+```C++
 #include <AceButton.h>
 using ace_button::AceButton;
 ```
@@ -251,7 +251,7 @@ Each physical button will be handled by an instance of `AceButton`. At a
 minimum, the instance needs to be told the pin number of the button. This can
 be done through the constructor:
 
-```
+```C++
 const uint8_t BUTTON_PIN = 2;
 
 AceButton button(BUTTON_PIN);
@@ -259,7 +259,7 @@ AceButton button(BUTTON_PIN);
 
 Or we can use the `init()` method in the `setup()`:
 
-```
+```C++
 AceButton button;
 
 void setup() {
@@ -270,7 +270,7 @@ void setup() {
 ```
 
 Both the constructor and the `init()` function take 3 optional parameters:
-```
+```C++
 AceButton(uint8_t pin = 0, uint8_t defaultReleasedState = HIGH, uint8_t id = 0);
 
 void init(uint8_t pin = 0, uint8_t defaultReleasedState = HIGH, uint8_t id = 0);
@@ -292,7 +292,7 @@ the value of `getDebounceDelay()` so that the various event detection logic can
 work properly. (If the debounce delay is 50 ms, `AceButton::check()` should be
 called every 10 ms or faster.)
 
-```
+```C++
 void loop() {
   ...
   button.check();
@@ -319,7 +319,7 @@ instances using dependency injection through the `AceButton(ButtonConfig&)`
 constructor. If this constructor is used, then the `AceButton::init()` method
 must be used to set the pin number of the button. For example:
 
-```
+```C++
 const uint8_t PIN1 = 2;
 const uint8_t PIN2 = 4;
 
@@ -428,7 +428,7 @@ normally not need to worry about the details.
 
 The event handler has the following signature:
 
-```
+```C++
 typedef void (*EventHandler)(AceButton* button, uint8_t eventType,
     uint8_t buttonState);
 ```
@@ -438,7 +438,7 @@ The event handler is registered with the `ButtonConfig` object, not with the
 `AceButton::setEventHandler()` is provided as a pass-through to the underlying
 `ButtonConfig` (see the _Single Button Simplifications_ section below):
 
-```
+```C++
 ButtonConfig buttonConfig;
 
 void handleEvent(AceButton* button, uint8_t eventType, uint8_t buttonState) {
@@ -459,7 +459,7 @@ is only necessary to save that information once, in the `ButtonConfig` object.
 
 **Pro Tip**: Comment out the unused parameter(s) in the `handleEvent()` method
 to avoid the `unused parameter` compiler warning:
-```
+```C++
 void handleEvent(AceButton* /* button */, uint8_t eventType,
     uint8_t /* buttonState */) {
   ...
@@ -468,7 +468,7 @@ void handleEvent(AceButton* /* button */, uint8_t eventType,
 The Arduino sketch compiler can get confused with the parameters commented out,
 so you may need to add a forward declaration for the `handleEvent()` method
 before the `setup()` method:
-```
+```C++
 void handleEvent(AceButton*, uint8_t, uint8_t);
 ```
 
@@ -516,7 +516,7 @@ when most of these would be unused. If the client code really wanted separate
 event handlers, it can be easily emulated by invoking them through the main
 event handler:
 
-```
+```C++
 void handleEvent(AceButton* button, uint8_t eventType, uint8_t buttonState) {
   switch (eventType) {
     case AceButton:kEventPressed:
@@ -580,13 +580,13 @@ control the behavior of `AceButton` event handling:
 
 These constants are used to set or clear the given flag:
 
-```
+```C++
 ButtonConfig* config = button.getButtonConfig();
 
 config->setFeature(ButtonConfig::kFeatureLongPress);
-...
+
 config->clearFeature(ButtonConfig::kFeatureLongPress);
-...
+
 if (config->isFeature(ButtonConfig::kFeatureLongPress)) {
   ...
 }
@@ -666,7 +666,7 @@ By default, no suppression is performed.
 As an example, to suppress the `Released` event after a `LongPressed` event
 (this is actually often the case), you would do this:
 
-```
+```C++
 ButtonConfig* config = button.getButtonConfig();
 config->setFeature(ButtonConfig::kFeatureSuppressAfterLongPress);
 ```
@@ -674,13 +674,13 @@ config->setFeature(ButtonConfig::kFeatureSuppressAfterLongPress);
 The special convenient constant `kFeatureSuppressAll` is equivalent of using all
 suppression constants:
 
-```
+```C++
 ButtonConfig* config = button.getButtonConfig();
 config->setFeature(ButtonConfig::kFeatureSuppressAll);
 ```
 
 All suppressions can be cleared by using:
-```
+```C++
 ButtonConfig* config = button.getButtonConfig();
 config->clearFeature(ButtonConfig::kFeatureSuppressAll);
 ```
@@ -729,7 +729,7 @@ events to the EventHandler:
 1. `kEventClicked` - at time 600ms (200ms + 400ms)
 
 The `ButtonConfig` configuration looks like this:
-```
+```C++
 ButtonConfig* buttonConfig = button.getButtonConfig();
 buttonConfig->setFeature(ButtonConfig::kFeatureDoubleClick);
 buttonConfig->setFeature(
@@ -754,7 +754,7 @@ user accidentally presses and releases the button to quickly, it generates a
 Clicked event, which will cause the program to do nothing.
 
 The `ButtonConfig` configuration looks like this:
-```
+```C++
 ButtonConfig* buttonConfig = button.getButtonConfig();
 buttonConfig->setEventHandler(handleEvent);
 buttonConfig->setFeature(ButtonConfig::kFeatureDoubleClick);
@@ -770,7 +770,7 @@ Released or a delayed Click is considered to be a "Click". This may be the best
 of both worlds.
 
 The `ButtonConfig` configuration looks like this:
-```
+```C++
 ButtonConfig* buttonConfig = button.getButtonConfig();
 buttonConfig->setEventHandler(handleEvent);
 buttonConfig->setFeature(ButtonConfig::kFeatureDoubleClick);
@@ -803,7 +803,7 @@ to make this simple case easy.
 These simplifying features allow a single button to be configured and used like
 this:
 
-```
+```C++
 AceButton button(BUTTON_PIN);
 
 void setup() {
@@ -824,7 +824,7 @@ void handleEvent(AceButton* button, uint8_t eventType, uint8_t buttonState) {
 To configure the System ButtonConfig, you may need to add something like
 this to the `setup()` section:
 
-```
+```C++
   button.getButtonConfig()->setFeature(ButtonConfig::kFeatureLongPress);
 ```
 

--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ to 14.)
 the size of the library. For a single button, the library consumed:
 * flash memory: 1100-1330 bytes
 * static memory: 14-28 bytes
+
 depending on the target board. See the README.md in the above link for more
 details.
 

--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ But the other two parameters may be optional in many cases.
 Finally, the `AceButton::check()` method should be called from the `loop()`
 method periodically. Roughly speaking, this should be about 5 times faster than
 the value of `getDebounceDelay()` so that the various event detection logic can
-work properly. (If the debounce delay is 50 ms, `AceButton::check()` should be
-called every 10 ms or faster.)
+work properly. (If the debounce delay is 20 ms, `AceButton::check()` should be
+called every 5 ms or faster.)
 
 ```C++
 void loop() {
@@ -362,7 +362,7 @@ _EventHandler Callback_ section.
 
 Here are the methods to retrieve the timing parameters:
 
-* `uint16_t getDebounceDelay();` (default: 50 ms)
+* `uint16_t getDebounceDelay();` (default: 20 ms)
 * `uint16_t getClickDelay();` (default: 200 ms)
 * `uint16_t getDoubleClickDelay();` (default: 400 ms)
 * `uint16_t getLongPressDelay();` (default: 1000 ms)

--- a/README.md
+++ b/README.md
@@ -892,11 +892,12 @@ to 14.)
 
 **Program size:**
 
-On the Arduino Nano (16 MHz ATmega328P):
-
-* `HelloButton` sketch: 1972 bytes flash
-* `HelloButton` sketch without `AceButton`: 622 bytes flash
-* Therefore, the AceButton library: 1350 bytes flash
+[LibrarySizeBenchmark](examples/LibrarySizeBenchmark/) was used to determine
+the size of the library. For a single button, the library consumed:
+* flash memory: 1100-1330 bytes
+* static memory: 14-28 bytes
+depending on the target board. See the README.md in the above link for more
+details.
 
 **CPU cycles:**
 
@@ -904,20 +905,20 @@ The profiling numbers for `AceButton::check()` can be found in
 [examples/AutoBenchmark](examples/AutoBenchmark).
 
 In summary, the average numbers for various boards are:
-* Arduino Nano: 17-20 microsesconds
-* Teensy 3.2: 4 microseconds
-* ESP8266: 7-8 microseconds
-* ESP32: 3-4 microseconds
+* Arduino Nano: 13-15 microsesconds
+* Teensy 3.2: 3 microseconds
+* ESP8266: 8-9 microseconds
+* ESP32: 2-3 microseconds
 
 ## System Requirements
 
 This library was developed and tested using:
-* [Arduino IDE 1.8.5](https://www.arduino.cc/en/Main/Software)
+* [Arduino IDE 1.8.5 - 1.8.7](https://www.arduino.cc/en/Main/Software)
 * [Teensyduino 1.41](https://www.pjrc.com/teensy/td_download.html)
-* [ESP8266 Arduino Core 2.4.1](https://arduino-esp8266.readthedocs.io/en/2.4.1/)
+* [ESP8266 Arduino Core 2.4.1 - 2.4.2](https://arduino-esp8266.readthedocs.io/en/2.4.2/)
 * [arduino-esp32](https://github.com/espressif/arduino-esp32)
 
-I used MacOS 10.13.3 and Ubuntu Linux 17.04 for most of my development.
+I used MacOS 10.13.3 and Ubuntu Linux 17.10 for most of my development.
 
 The library has been verified to work on the following hardware:
 

--- a/README.md
+++ b/README.md
@@ -287,9 +287,11 @@ void init(uint8_t pin = 0, uint8_t defaultReleasedState = HIGH, uint8_t id = 0);
 The `pin` must be defined either through the constructor or the `init()` method.
 But the other two parameters may be optional in many cases.
 
-Finally, the `ButtonConfig::check()` method should be called from the `loop()`
-method periodically. Ideally, this should be every 10-20 milliseconds or faster
-so that the various event detection logic can work properly.
+Finally, the `AceButton::check()` method should be called from the `loop()`
+method periodically. Roughly speaking, this should be about 5 times faster than
+the value of `getDebounceDelay()` so that the various event detection logic can
+work properly. (If the debounce delay is 50 ms, `AceButton::check()` should be
+called every 10 ms or faster.)
 
 ```
 void loop() {
@@ -518,7 +520,7 @@ The `EventHandler` function received 3 parameters from the `AceButton`:
 The `aceButton` pointer should be used only to extract information about the
 button that triggered the event. It should **not** be used to modify the
 button's internal variables in any way within the eventHandler. The logic in
-`AceButton.check()` assumes that those internal variable are held constant,
+`AceButton::check()` assumes that those internal variable are held constant,
 and if they are changed by the eventHandler, unpredictable results may occur.
 (I was tempted to make the `aceButton` a pointer to a `const AceButton`
 but this cause too many viral changes to the code which seemed to increase

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Here are the high-level features of the AceButton library:
     * LongPressed
     * RepeatPressed
 * can distinguish between Clicked and DoubleClicked
-* configurations adjustable at runtime or compile-time
+* adjustable configurations at runtime or compile-time
     * timing parameters
     * `digitalRead()` button read function can be overridden
     * `millis()` clock function can be overridden
 * small memory footprint
     * each `AceButton` consumes 14 bytes
-    * each `ButtonConfig` consumes 8 bytes
+    * each `ButtonConfig` consumes 20 bytes
     * one System `ButtonConfig` instance created automatically by the library
 * thoroughly unit tested using [AUnit](https://github.com/bxparks/AUnit)
 * properly handles reboots while the button is pressed
@@ -188,7 +188,6 @@ The following example sketches are provided:
     * same as SingleButton.ino but with an external pull-down resistor
 * [Stopwatch.ino](examples/Stopwatch)
     * measures the speed of `AceButton:check()` with a start/stop/reset button
-    * shows example use of `AdjustableButtonConfig`
     * uses `kFeatureLongPress`
 * [TunerButtons.ino](examples/TunerButtons)
     * implements 5 radio buttons (tune-up, tune-down, and 3 presets)
@@ -363,42 +362,15 @@ _EventHandler Callback_ section.
 
 Here are the methods to retrieve the timing parameters:
 
-* `virtual uint16_t getDebounceDelay();`
-* `virtual uint16_t getClickDelay();`
-* `virtual uint16_t getDoubleClickDelay();`
-* `virtual uint16_t getLongPressDelay();`
-* `virtual uint16_t getRepeatPressDelay();`
-* `virtual uint16_t getRepeatPressInterval();`
+* `uint16_t getDebounceDelay();` (default: 50 ms)
+* `uint16_t getClickDelay();` (default: 200 ms)
+* `uint16_t getDoubleClickDelay();` (default: 400 ms)
+* `uint16_t getLongPressDelay();` (default: 1000 ms)
+* `uint16_t getRepeatPressDelay();` (default: 1000 ms)
+* `uint16_t getRepeatPressInterval();` (default: 200 ms)
 
-The values of these timing parameters are hardwired at compile time. They can be
-changed in two ways:
-
-1. Use a user-defined subclass to override one or more of these `virtual`
-   methods. Normally we avoid virtual methods in an embedded environment. But we
-   wanted the ability to plug in different types of `ButtonConfig` into the
-   `AceButton` class, and this C++ feature solves this problem very well. The
-   cost is 2 extra bytes for the virtual table pointer in each instance of
-   `ButtonConfig`, and some extra CPU overhead during the call to the virtual
-   functions.
-1. Use the `AdjustableButtonConfig` (see below) to configure these parameters at
-   run-time.
-
-An example of a user-defined subclass to override one of these parameters at
-compile-time would look like this:
-
-```
-class MyButtonConfig: public ButtonConfig {
-  public:
-    virtual uint16_t getClickDelay() override { return 250; }
-};
-```
-
-#### AdjustableButtonConfig
-
-The `AdjustableButtonConfig` is a subclass of `ButtonConfig` that allows the
-timing parameters of `ButtonConfig` to be changed at run-time. Everywhere that
-you see a `ButtonConfig` uses, you can substitute an `AdjustableButtonConfig`.
-It provides the following methods to change the timing parameters:
+The default values of each timing parameter can be changed at run-time using
+the following methods:
 
 * `void setDebounceDelay(uint16_t debounceDelay);`
 * `void setClickDelay(uint16_t clickDelay);`
@@ -406,10 +378,6 @@ It provides the following methods to change the timing parameters:
 * `void setLongPressDelay(uint16_t longPressDelay);`
 * `void setRepeatPressDelay(uint16_t repeatPressDelay);`
 * `void setRepeatPressInterval(uint16_t repeatPressInterval);`
-
-The cost of this flexibility is the larger static memory usage of an
-`AdjustableButtonConfig`, taking up 17 bytes of memory compared to 5 bytes for
-a `ButtonConfig`.
 
 #### Hardware Dependencies
 
@@ -916,8 +884,7 @@ Here are the sizes of the various classes on the 8-bit AVR microcontrollers
 (Arduino Uno, Nano, etc):
 
 * sizeof(AceButton): 14
-* sizeof(ButtonConfig): 8
-* sizeof(AdjustableButtonConfig): 20
+* sizeof(ButtonConfig): 20
 
 (An early version of `AceButton`, with only half of the functionality, consumed
 40 bytes. It got down to 11 bytes before additional functionality increased it

--- a/README.md
+++ b/README.md
@@ -998,6 +998,16 @@ I changed to the MIT License starting with version 1.1 because the MIT License
 is so simple to understand. I could not be sure that I understood what the
 Apache License 2.0 meant.
 
+## Feedback and Support
+
+If you have any questions, comments, bug reports, or feature requests, please
+file a GitHub ticket or send me an email. I'd love to hear about how this
+software and its documentation can be improved. Instead of forking the
+repository to modify or add a feature for your own projects, let me have a
+chance to incorporate the change into the main repository so that your external
+dependencies are simpler and so that others can benefit. I can't promise that I
+will incorporate everything, but I will give your ideas serious consideration.
+
 ## Author
 
 Created by Brian T. Park (brian@xparks.net).

--- a/examples/AutoBenchmark/README.md
+++ b/examples/AutoBenchmark/README.md
@@ -33,11 +33,11 @@ All times are in microseconds. The "samples" column is the number of
 ------------------------+-------------+---------+
 button event            | min/avg/max | samples |
 ------------------------+-------------+---------+
-idle                    |  16/ 17/ 24 | 1927    |
-press/release           |   8/ 18/ 28 | 1916    |
-click                   |   8/ 17/ 28 | 1921    |
-double click            |   8/ 17/ 32 | 1918    |
-long press/repeat press |   8/ 20/ 28 | 1917    |
+idle                    |  12/ 13/ 20 | 1934    |
+press/release           |   8/ 14/ 20 | 1925    |
+click                   |   8/ 14/ 24 | 1925    |
+double click            |   8/ 13/ 24 | 1925    |
+long press/repeat press |   8/ 15/ 24 | 1927    |
 ------------------------+-------------+---------+
 ```
 
@@ -49,27 +49,27 @@ long press/repeat press |   8/ 20/ 28 | 1917    |
 ------------------------+-------------+---------+
 button event            | min/avg/max | samples |
 ------------------------+-------------+---------+
-idle                    |  16/ 17/ 28 | 1928    |
-press/release           |   8/ 18/ 28 | 1919    |
-click                   |   8/ 17/ 28 | 1923    |
-double click            |   8/ 17/ 36 | 1920    |
-long press/repeat press |   8/ 20/ 32 | 1918    |
+idle                    |  12/ 13/ 24 | 1935    |
+press/release           |   8/ 14/ 24 | 1928    |
+click                   |   8/ 13/ 24 | 1928    |
+double click            |   8/ 13/ 24 | 1926    |
+long press/repeat press |   8/ 15/ 28 | 1928    |
 ------------------------+-------------+---------+
 ```
 
 ### Teensy 3.2
 
-* 72 MHz ARM Cortex-M4
+* 96 MHz ARM Cortex-M4
 
 ```
 ------------------------+-------------+---------+
 button event            | min/avg/max | samples |
 ------------------------+-------------+---------+
-idle                    |   4/  4/  6 | 1983    |
-press/release           |   1/  4/  7 | 1981    |
-click                   |   1/  4/  7 | 1982    |
-double click            |   1/  4/  8 | 1982    |
-long press/repeat press |   1/  4/  7 | 1980    |
+idle                    |   3/  3/  5 | 1985    |
+press/release           |   1/  3/  6 | 1983    |
+click                   |   1/  3/  6 | 1984    |
+double click            |   1/  3/  6 | 1984    |
+long press/repeat press |   1/  3/  6 | 1983    |
 ------------------------+-------------+---------+
 ```
 
@@ -81,11 +81,11 @@ long press/repeat press |   1/  4/  7 | 1980    |
 ------------------------+-------------+---------+
 button event            | min/avg/max | samples |
 ------------------------+-------------+---------+
-idle                    |   7/  7/ 12 | 1922    |
-press/release           |   5/  7/ 37 | 1921    |
-click                   |   5/  7/ 18 | 1922    |
-double click            |   5/  7/ 50 | 1917    |
-long press/repeat press |   5/  8/ 55 | 1910    |
+idle                    |   7/  8/ 24 | 1922    |
+press/release           |   6/  8/ 53 | 1919    |
+click                   |   6/  8/ 50 | 1920    |
+double click            |   6/  8/ 67 | 1910    |
+long press/repeat press |   6/  9/ 60 | 1894    |
 ------------------------+-------------+---------+
 ```
 
@@ -102,10 +102,10 @@ click" and "long press" samples are taken, causing the extra latency.
 ------------------------+-------------+---------+
 button event            | min/avg/max | samples |
 ------------------------+-------------+---------+
-idle                    |   4/  4/  4 | 2002    |
-press/release           |   3/  3/ 10 | 2002    |
-click                   |   3/  3/  9 | 2002    |
-double click            |   3/  3/  7 | 2002    |
-long press/repeat press |   3/  3/  4 | 2002    |
+idle                    |   3/  3/  3 | 2002    |
+press/release           |   2/  2/  8 | 2002    |
+click                   |   2/  2/  7 | 2002    |
+double click            |   2/  2/  4 | 2002    |
+long press/repeat press |   2/  2/  4 | 2002    |
 ------------------------+-------------+---------+
 ```

--- a/examples/CapacitiveButton/CapacitiveButton.ino
+++ b/examples/CapacitiveButton/CapacitiveButton.ino
@@ -9,6 +9,10 @@
  * Brian T. Park 2018
  */
 
+#if defined(ESP32) || defined(ESP8266)
+  #error ESP32 or ESP8266 not supported
+#endif
+
 #include <CapacitiveSensor.h>
 #include <AceButton.h>
 using namespace ace_button;

--- a/examples/HelloButton/HelloButton.ino
+++ b/examples/HelloButton/HelloButton.ino
@@ -8,7 +8,11 @@
 #include <AceButton.h>
 using namespace ace_button;
 
+#if defined(ENVIRONMENT_NANO)
+const int BUTTON_PIN = RIGHT_BUTTON;
+#else
 const int BUTTON_PIN = 2; // change this to the button pin
+#endif
 
 #ifdef ESP32
   // Different ESP32 boards use different pins

--- a/examples/HelloButton/HelloButton.ino
+++ b/examples/HelloButton/HelloButton.ino
@@ -6,30 +6,19 @@
  */
 
 #include <AceButton.h>
+
 using namespace ace_button;
 
-#if !defined(AUNITER)
-  #define AUNITER_MICRO
-  #warning Assuming AUNITER_MICRO
-#endif
-
-#if defined(AUNITER_NANO)
-  const int BUTTON_PIN = AUNITER_RIGHT_BUTTON;
-  const int LED_PIN = LED_BUILTIN;
-  const int LED_ON = HIGH;
-  const int LED_OFF = LOW;
-#elif defined(AUNITER_MICRO)
-  const int BUTTON_PIN = 3;
-  const int LED_PIN = LED_BUILTIN_RX;
-  const int LED_ON = LOW;
-  const int LED_OFF = HIGH;
-#elif defined(AUNITER_ESP32)
-  // Different ESP32 boards use different pins, so just pick one for now
+// Some ESP32 boards have multiple builtin LEDs so don't define LED_BUILTIN.
+#if defined(ESP32)
   const int LED_PIN = 2;
 #else
-  const int BUTTON_PIN = 2; // change this to the button pin
   const int LED_PIN = LED_BUILTIN;
 #endif
+
+const int BUTTON_PIN = 2;
+const int LED_ON = HIGH;
+const int LED_OFF = LOW;
 
 AceButton button(BUTTON_PIN);
 

--- a/examples/HelloButton/HelloButton.ino
+++ b/examples/HelloButton/HelloButton.ino
@@ -8,28 +8,41 @@
 #include <AceButton.h>
 using namespace ace_button;
 
-#if defined(AUNITER_NANO)
-const int BUTTON_PIN = AUNITER_RIGHT_BUTTON;
-#else
-const int BUTTON_PIN = 2; // change this to the button pin
+#if !defined(AUNITER)
+  #define AUNITER_MICRO
+  #warning Assuming AUNITER_MICRO
 #endif
 
-#ifdef ESP32
-  // Different ESP32 boards use different pins
+#if defined(AUNITER_NANO)
+  const int BUTTON_PIN = AUNITER_RIGHT_BUTTON;
+  const int LED_PIN = LED_BUILTIN;
+  const int LED_ON = HIGH;
+  const int LED_OFF = LOW;
+#elif defined(AUNITER_MICRO)
+  const int BUTTON_PIN = 3;
+  const int LED_PIN = LED_BUILTIN_RX;
+  const int LED_ON = LOW;
+  const int LED_OFF = HIGH;
+#elif defined(AUNITER_ESP32)
+  // Different ESP32 boards use different pins, so just pick one for now
   const int LED_PIN = 2;
 #else
+  const int BUTTON_PIN = 2; // change this to the button pin
   const int LED_PIN = LED_BUILTIN;
 #endif
-
-// LED states. Some microcontrollers wire their built-in LED the reverse.
-const int LED_ON = HIGH;
-const int LED_OFF = LOW;
 
 AceButton button(BUTTON_PIN);
 
 void handleEvent(AceButton*, uint8_t, uint8_t);
 
 void setup() {
+  delay(2000);
+
+#if defined(ARDUINO_AVR_LEONARDO)
+  RXLED0; // LED off
+  TXLED0; // LED off
+#endif
+
   pinMode(LED_PIN, OUTPUT);
   pinMode(BUTTON_PIN, INPUT_PULLUP);
   button.setEventHandler(handleEvent);

--- a/examples/HelloButton/HelloButton.ino
+++ b/examples/HelloButton/HelloButton.ino
@@ -8,8 +8,8 @@
 #include <AceButton.h>
 using namespace ace_button;
 
-#if defined(ENVIRONMENT_NANO)
-const int BUTTON_PIN = RIGHT_BUTTON;
+#if defined(AUNITER_NANO)
+const int BUTTON_PIN = AUNITER_RIGHT_BUTTON;
 #else
 const int BUTTON_PIN = 2; // change this to the button pin
 #endif

--- a/examples/LibrarySizeBenchmark/LibrarySizeBenchmark.ino
+++ b/examples/LibrarySizeBenchmark/LibrarySizeBenchmark.ino
@@ -1,0 +1,66 @@
+/*
+ * A copy of HelloWorld which allows us to measure the size of the AceButton
+ * library. Set USE_ACE_BUTTON to 1 to include AceButton, 0 to exclude
+ * AceButton.
+ */
+
+#include <AceButton.h>
+
+using namespace ace_button;
+
+// Set this to 0 to disable the AceButton code, so that we can
+// figure out how many bytes is consumed by the AceButton library.
+#define USE_ACE_BUTTON 1
+
+// Some ESP32 boards have multiple builtin LEDs so don't define LED_BUILTIN.
+#if defined(ESP32)
+  const int LED_PIN = 2;
+#else
+  const int LED_PIN = LED_BUILTIN;
+#endif
+
+const int BUTTON_PIN = 2;
+const int LED_ON = HIGH;
+const int LED_OFF = LOW;
+
+#if USE_ACE_BUTTON == 1
+AceButton button(BUTTON_PIN);
+
+void handleEvent(AceButton*, uint8_t, uint8_t);
+#endif
+
+void setup() {
+  delay(2000);
+
+#if defined(ARDUINO_AVR_LEONARDO)
+  RXLED0; // LED off
+  TXLED0; // LED off
+#endif
+
+  pinMode(LED_PIN, OUTPUT);
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
+
+#if USE_ACE_BUTTON == 1
+  button.setEventHandler(handleEvent);
+#endif
+}
+
+void loop() {
+#if USE_ACE_BUTTON == 1
+  button.check();
+#endif
+}
+
+#if USE_ACE_BUTTON == 1
+void handleEvent(AceButton* /* button */, uint8_t eventType,
+    uint8_t /* buttonState */) {
+  switch (eventType) {
+    case AceButton::kEventPressed:
+      digitalWrite(LED_PIN, LED_ON);
+      break;
+    case AceButton::kEventReleased:
+      digitalWrite(LED_PIN, LED_OFF);
+      break;
+  }
+}
+#endif

--- a/examples/LibrarySizeBenchmark/README.md
+++ b/examples/LibrarySizeBenchmark/README.md
@@ -1,0 +1,18 @@
+# LibrarySizeBenchmark
+
+A small sketch to determine the size of the AceButton library.
+First we compile it with `#define USE_ACE_BUTTON 1` to include the library.
+Then we compile it with `#define USE_ACE_BUTTON 0` to exclude the library.
+The difference should give us a rough idea of the size of the library.
+(The compiler will produce slightly difference results for different programs.)
+
+```
+-------------+--------------+---------------+------------+
+board        | AceButton    | w/o AceButton | Difference |
+-------------+--------------+---------------+------------+
+ATmega328P   |   2282/   55 | 1126   /  41  | 1156/14    |
+ESP8266      | 249364/28076 | 248032/28048  | 1332/28    |
+ESP32        | 195588/14044 | 194424/14028  | 1164/16    |
+Teensy 3.2   |   9852/ 3476 |   8760/ 3460  | 1092/16    |
+-------------+--------------+---------------+------------+
+```

--- a/examples/Stopwatch/Stopwatch.ino
+++ b/examples/Stopwatch/Stopwatch.ino
@@ -19,14 +19,8 @@ using namespace ace_button;
 // The pin number attached to the button.
 const uint8_t BUTTON_PIN = 2;
 
-// Use an instance of AdjustableButtonConfig for demo purposes. We could have
-// just used the default System ButtonConfig since a long press delay of 1000 ms
-// is good enough. But this shows how to configure an AceButton to use a
-// different ButtonConfig.
-AdjustableButtonConfig adjustableButtonConfig;
-
-// Create one button which uses AdjustableButtonConfig.
-AceButton button(&adjustableButtonConfig);
+// Create one button.
+AceButton button;
 
 // counters to determine the duration of a single call to AceButton::check()
 uint16_t innerLoopCounter = 0;
@@ -58,9 +52,10 @@ void setup() {
 
   // Configure the ButtonConfig with the event handler and enable LongPress.
   // SupressAfterLongPress is optional since we don't do anything if we get it.
-  adjustableButtonConfig.setEventHandler(handleEvent);
-  adjustableButtonConfig.setFeature(ButtonConfig::kFeatureLongPress);
-  adjustableButtonConfig.setLongPressDelay(2000);
+  ButtonConfig* buttonConfig = button.getButtonConfig();
+  buttonConfig->setEventHandler(handleEvent);
+  buttonConfig->setFeature(ButtonConfig::kFeatureLongPress);
+  buttonConfig->setLongPressDelay(2000);
 
   Serial.println(F("setup(): stopwatch ready"));
 }
@@ -144,16 +139,16 @@ void handleEvent(AceButton* /* button */, uint8_t eventType,
 
 void enableAllEvents() {
   Serial.println(F("enabling high level events"));
-  adjustableButtonConfig.setFeature(ButtonConfig::kFeatureClick);
-  adjustableButtonConfig.setFeature(ButtonConfig::kFeatureDoubleClick);
-  adjustableButtonConfig.setFeature(ButtonConfig::kFeatureLongPress);
-  adjustableButtonConfig.setFeature(ButtonConfig::kFeatureRepeatPress);
+  button.getButtonConfig()->setFeature(ButtonConfig::kFeatureClick);
+  button.getButtonConfig()->setFeature(ButtonConfig::kFeatureDoubleClick);
+  button.getButtonConfig()->setFeature(ButtonConfig::kFeatureLongPress);
+  button.getButtonConfig()->setFeature(ButtonConfig::kFeatureRepeatPress);
 }
 
 void disableAllEvents() {
   Serial.println(F("disabling high level events"));
-  adjustableButtonConfig.clearFeature(ButtonConfig::kFeatureClick);
-  adjustableButtonConfig.clearFeature(ButtonConfig::kFeatureDoubleClick);
-  adjustableButtonConfig.clearFeature(ButtonConfig::kFeatureLongPress);
-  adjustableButtonConfig.clearFeature(ButtonConfig::kFeatureRepeatPress);
+  button.getButtonConfig()->clearFeature(ButtonConfig::kFeatureClick);
+  button.getButtonConfig()->clearFeature(ButtonConfig::kFeatureDoubleClick);
+  button.getButtonConfig()->clearFeature(ButtonConfig::kFeatureLongPress);
+  button.getButtonConfig()->clearFeature(ButtonConfig::kFeatureRepeatPress);
 }

--- a/examples/TunerButtons/TunerButtons.ino
+++ b/examples/TunerButtons/TunerButtons.ino
@@ -26,13 +26,12 @@ const uint16_t FM_FREQ_MIN = 879; // 87.9 MHz
 const uint16_t FM_FREQ_MAX = 1079; // 107.9 MHz
 const uint16_t FM_FREQ_DELTA = 2; // 0.2 MHz increments in USA
 
-// Preset buttons.
-ButtonConfig presetConfig;
-AceButton presetButton1(&presetConfig);
-AceButton presetButton2(&presetConfig);
-AceButton presetButton3(&presetConfig);
+// Preset buttons use the SystemButtonConfig.
+AceButton presetButton1;
+AceButton presetButton2;
+AceButton presetButton3;
 
-// Tune up or down buttons.
+// Tune up or down buttons use a different ButtonConfig.
 ButtonConfig tuneConfig;
 AceButton tuneDownButton(&tuneConfig);
 AceButton tuneUpButton(&tuneConfig);
@@ -60,9 +59,10 @@ void setup() {
 
   // Configs for the preset buttons. Need Released event to change the station,
   // and LongPressed to memorize the current station. Don't need Clicked.
-  presetConfig.setEventHandler(handlePresetEvent);
-  presetConfig.setFeature(ButtonConfig::kFeatureLongPress);
-  presetConfig.setFeature(ButtonConfig::kFeatureSuppressAfterLongPress);
+  ButtonConfig* presetConfig = ButtonConfig::getSystemButtonConfig();
+  presetConfig->setEventHandler(handlePresetEvent);
+  presetConfig->setFeature(ButtonConfig::kFeatureLongPress);
+  presetConfig->setFeature(ButtonConfig::kFeatureSuppressAfterLongPress);
 
   // Configs for the tune-up and tune-down buttons. Need RepeatPress instead of
   // LongPress.

--- a/keywords.txt
+++ b/keywords.txt
@@ -9,7 +9,6 @@
 AceButton	KEYWORD1
 EventHandler	KEYWORD1
 ButtonConfig	KEYWORD1
-AdjustableButtonConfig	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/src/ace_button/AceButton.h
+++ b/src/ace_button/AceButton.h
@@ -43,8 +43,8 @@ namespace ace_button {
  * - kEventRepeatPressed
  *
  * The check() method should be called from the loop() at least 2-3 times during
- * the debouncing time period. For 50 ms delay, the check() method should be
- * called at a minimum of every 15-20 ms. The execution time of check() on a 16
+ * the debouncing time period. For 20 ms delay, the check() method should be
+ * called at a minimum of every 5 ms. The execution time of check() on a 16
  * MHz Arduino ATmega328P MCU seems to about about 12-14 microseconds.
  */
 class AceButton {
@@ -195,8 +195,8 @@ class AceButton {
 
     /**
      * Check state of button and trigger event processing. This method should be
-     * called from the loop() method in Arduino every 2-3 times during the
-     * getDebounceDelay() time (default 50 ms), so about every 10-20 ms. If this
+     * called from the loop() method in Arduino every 4-5 times during the
+     * getDebounceDelay() time (default 20 ms), so about every 5 ms. If this
      * is called less often than that, the debouncing algorithm may not work
      * correctly, which may cause other event detection algorithms to fail.
      */

--- a/src/ace_button/AdjustableButtonConfig.h
+++ b/src/ace_button/AdjustableButtonConfig.h
@@ -30,6 +30,10 @@ SOFTWARE.
 namespace ace_button {
 
 /**
+ * Warning: This class is deprecated and replaced with its parent ButtonConfig.
+ * class. You can just use ButtonConfig everywhere you previously used
+ * AdjustableButtonConfig.
+ *
  * A subclass of ButtonConfig which allows the user to override the varous
  * timing parameters of ButtonConfig at runtime. Each timing parameter
  * is stored in a member variable, so an instance of AdjustableButtonConfig
@@ -37,92 +41,6 @@ namespace ace_button {
  * these parameters to be changed at runtime by the user.
  */
 class AdjustableButtonConfig: public ButtonConfig {
-  public:
-    AdjustableButtonConfig() {
-      initInternal();
-    }
-
-    virtual void init() override {
-      ButtonConfig::init();
-      initInternal();
-    }
-
-    virtual uint16_t getDebounceDelay() override {
-      return mDebounceDelay;
-    }
-
-    virtual uint16_t getClickDelay() override {
-      return mClickDelay;
-    }
-
-    virtual uint16_t getDoubleClickDelay() override {
-      return mDoubleClickDelay;
-    }
-
-    virtual uint16_t getLongPressDelay() override {
-      return mLongPressDelay;
-    }
-
-    virtual uint16_t getRepeatPressDelay() override {
-      return mRepeatPressDelay;
-    }
-
-    virtual uint16_t getRepeatPressInterval() override {
-      return mRepeatPressInterval;
-    }
-
-    /** Set the debounceDelay. */
-    void setDebounceDelay(uint16_t debounceDelay) {
-      mDebounceDelay = debounceDelay;
-    }
-
-    /** Set the clickDelay. */
-    void setClickDelay(uint16_t clickDelay) {
-      mClickDelay = clickDelay;
-    }
-
-    /** Set the doubleClickDelay. */
-    void setDoubleClickDelay(uint16_t doubleClickDelay) {
-      mDoubleClickDelay = doubleClickDelay;
-    }
-
-    /** Set the longPressDelay. */
-    void setLongPressDelay(uint16_t longPressDelay) {
-      mLongPressDelay = longPressDelay;
-    }
-
-    /** Set the repeatPressDelay. */
-    void setRepeatPressDelay(uint16_t repeatPressDelay) {
-      mRepeatPressDelay = repeatPressDelay;
-    }
-
-    /** Set the repeatPressInterval. */
-    void setRepeatPressInterval(uint16_t repeatPressInterval) {
-      mRepeatPressInterval = repeatPressInterval;
-    }
-
-  private:
-    // Disable copy-constructor and assignment operator
-    AdjustableButtonConfig(const AdjustableButtonConfig&) = delete;
-    AdjustableButtonConfig& operator=(const AdjustableButtonConfig&) = delete;
-
-    // This method must remain non-virtual so that it can be called safely from
-    // the constructor.
-    void initInternal() {
-      mDebounceDelay = kDebounceDelay;
-      mClickDelay = kClickDelay;
-      mDoubleClickDelay = kDoubleClickDelay;
-      mLongPressDelay = kLongPressDelay;
-      mRepeatPressDelay = kRepeatPressDelay;
-      mRepeatPressInterval = kRepeatPressInterval;
-    }
-
-    uint16_t mDebounceDelay;
-    uint16_t mClickDelay;
-    uint16_t mDoubleClickDelay;
-    uint16_t mLongPressDelay;
-    uint16_t mRepeatPressDelay;
-    uint16_t mRepeatPressInterval;
 };
 
 }

--- a/src/ace_button/ButtonConfig.cpp
+++ b/src/ace_button/ButtonConfig.cpp
@@ -29,8 +29,4 @@ namespace ace_button {
 // The default "System" instance of a ButtonConfig.
 ButtonConfig ButtonConfig::sSystemButtonConfig;
 
-ButtonConfig::ButtonConfig():
-    mEventHandler(nullptr),
-    mFeatureFlags(0) {}
-
 }

--- a/src/ace_button/ButtonConfig.h
+++ b/src/ace_button/ButtonConfig.h
@@ -74,7 +74,7 @@ class ButtonConfig {
     // time of an 'unsigned long' (i.e. 49.7 days).
 
     /** Default value returned by getDebounceDelay(). */
-    static const uint16_t kDebounceDelay = 50;
+    static const uint16_t kDebounceDelay = 20;
 
     /** Default value returned by getClickDelay(). */
     static const uint16_t kClickDelay = 200;

--- a/src/ace_button/ButtonConfig.h
+++ b/src/ace_button/ButtonConfig.h
@@ -46,17 +46,8 @@ class TimingStats;
  * Each AceButton instance contains a pointer to an instance of ButtonConfig,
  * and an instance of ButtonConfig will be shared among multiple AceButtons.
  *
- * Most of the parameters are actually hardwired into the various virtual
- * methods below. This has the advantage of reducing memory consumption of even
- * this class. If a parameter needs to be changed, there are 2 options:
- *
- * 1. Use the AdjustableButtonConfig subclass which allows all of these
- *    parameters to be changed at runtime, at the cost of additional static
-      memory usage to hold those parameters.
- * 2. Subclass this ButtonConfig class, then override only the specific
- *    method to modify the specific timing parameter. This has the advantage
- *    of consuming no additional static RAM, at the expense of creating
- *    another class.
+ * Various timing parameters are given default values. They can be
+ * overridden by the user.
  *
  * A single default "System" ButtonConfig instance is created automatically and
  * can be accessed using the ButtConfig::getSystemButtonConfig() static method.
@@ -174,7 +165,7 @@ class ButtonConfig {
         uint8_t buttonState);
 
     /** Constructor. */
-    ButtonConfig();
+    ButtonConfig() {}
 
     // These configuration methods are virtual so that they can be overriddden.
     // Subclasses can override at the class-level by defining a new virtual
@@ -182,22 +173,22 @@ class ButtonConfig {
     // the parameter with each instance of this class.
 
     /** Milliseconds to wait for debouncing. */
-    virtual uint16_t getDebounceDelay() { return kDebounceDelay; }
+    uint16_t getDebounceDelay() { return mDebounceDelay; }
 
     /** Milliseconds to wait for a possible click. */
-    virtual uint16_t getClickDelay() { return kClickDelay; }
+    uint16_t getClickDelay() { return mClickDelay; }
 
     /**
      * Milliseconds between the first and second click to register as a
      * double-click.
      */
-    virtual uint16_t getDoubleClickDelay() {
-      return kDoubleClickDelay;
+    uint16_t getDoubleClickDelay() {
+      return mDoubleClickDelay;
     }
 
     /** Milliseconds for a long press event. */
-    virtual uint16_t getLongPressDelay() {
-      return kLongPressDelay;
+    uint16_t getLongPressDelay() {
+      return mLongPressDelay;
     }
 
     /**
@@ -206,15 +197,45 @@ class ButtonConfig {
      * as this delay has passed. Subsequent events will fire after
      * getRepeatPressInterval() time.
      */
-    virtual uint16_t getRepeatPressDelay() {
-      return kRepeatPressDelay;
+    uint16_t getRepeatPressDelay() {
+      return mRepeatPressDelay;
     }
 
     /**
      * Milliseconds between two successive RepeatPressed events.
      */
-    virtual uint16_t getRepeatPressInterval() {
-      return kRepeatPressInterval;
+    uint16_t getRepeatPressInterval() {
+      return mRepeatPressInterval;
+    }
+
+    /** Set the debounceDelay. */
+    void setDebounceDelay(uint16_t debounceDelay) {
+      mDebounceDelay = debounceDelay;
+    }
+
+    /** Set the clickDelay. */
+    void setClickDelay(uint16_t clickDelay) {
+      mClickDelay = clickDelay;
+    }
+
+    /** Set the doubleClickDelay. */
+    void setDoubleClickDelay(uint16_t doubleClickDelay) {
+      mDoubleClickDelay = doubleClickDelay;
+    }
+
+    /** Set the longPressDelay. */
+    void setLongPressDelay(uint16_t longPressDelay) {
+      mLongPressDelay = longPressDelay;
+    }
+
+    /** Set the repeatPressDelay. */
+    void setRepeatPressDelay(uint16_t repeatPressDelay) {
+      mRepeatPressDelay = repeatPressDelay;
+    }
+
+    /** Set the repeatPressInterval. */
+    void setRepeatPressInterval(uint16_t repeatPressInterval) {
+      mRepeatPressInterval = repeatPressInterval;
     }
 
     // The getClock() and readButton() are external dependencies that normally
@@ -305,24 +326,31 @@ class ButtonConfig {
     }
 
   private:
-    // Disable copy-constructor and assignment operator
-    ButtonConfig(const ButtonConfig&) = delete;
-    ButtonConfig& operator=(const ButtonConfig&) = delete;
-
-    /** The event handler for all buttons associated with this ButtonConfig. */
-    EventHandler mEventHandler;
-
-    /** A bit mask flag that activates certain features. */
-    FeatureFlagType mFeatureFlags;
-
-    /** The timing stats object. */
-    TimingStats* mTimingStats;
-
     /**
      * A single static instance of ButtonConfig provided by default to all
      * AceButton instances.
      */
     static ButtonConfig sSystemButtonConfig;
+
+    // Disable copy-constructor and assignment operator
+    ButtonConfig(const ButtonConfig&) = delete;
+    ButtonConfig& operator=(const ButtonConfig&) = delete;
+
+    /** The event handler for all buttons associated with this ButtonConfig. */
+    EventHandler mEventHandler = nullptr;
+
+    /** A bit mask flag that activates certain features. */
+    FeatureFlagType mFeatureFlags = 0;
+
+    /** The timing stats object. */
+    TimingStats* mTimingStats = nullptr;
+
+    uint16_t mDebounceDelay = kDebounceDelay;
+    uint16_t mClickDelay = kClickDelay;
+    uint16_t mDoubleClickDelay = kDoubleClickDelay;
+    uint16_t mLongPressDelay = kLongPressDelay;
+    uint16_t mRepeatPressDelay = kRepeatPressDelay;
+    uint16_t mRepeatPressInterval = kRepeatPressInterval;
 };
 
 }

--- a/tests/AceButtonTest/AceButtonTest.ino
+++ b/tests/AceButtonTest/AceButtonTest.ino
@@ -88,6 +88,11 @@ void setup() {
 
   testableConfig.setEventHandler(handleEvent);
 
+  // The default was 50 ms (not the current 20 ms) when these tests were written
+  // and some of the timing delays are hardcoded to assume that, so we have to
+  // revert back to the old value.
+  testableConfig.setDebounceDelay(50);
+
   Serial.print(F("sizeof(AceButton): "));
   Serial.println(sizeof(AceButton));
   Serial.print(F("sizeof(ButtonConfig): "));

--- a/tests/AceButtonTest/AceButtonTest.ino
+++ b/tests/AceButtonTest/AceButtonTest.ino
@@ -68,7 +68,6 @@ const uint8_t PIN = 13;
 const uint8_t BUTTON_ID = 1;
 
 ButtonConfig buttonConfig;
-AdjustableButtonConfig adjustableConfig;
 
 TestableButtonConfig testableConfig;
 AceButton button(&testableConfig);
@@ -93,8 +92,6 @@ void setup() {
   Serial.println(sizeof(AceButton));
   Serial.print(F("sizeof(ButtonConfig): "));
   Serial.println(sizeof(ButtonConfig));
-  Serial.print(F("sizeof(AdjustableButtonConfig): "));
-  Serial.println(sizeof(AdjustableButtonConfig));
   Serial.print(F("sizeof(TestableButtonConfig): "));
   Serial.println(sizeof(TestableButtonConfig));
 
@@ -243,25 +240,26 @@ test(testable_config) {
   assertEqual(LOW, button.getButtonConfig()->readButton(0));
 }
 
-// Test that the AdjustableButtonConfig overrides properly.
+// Test that the ButtonConfig parameters are mutable, just like the
+// original AdjustableButtonConfig.
 test(adjustable_config) {
-  adjustableConfig.setDebounceDelay(1);
-  assertEqual((uint16_t)1, adjustableConfig.getDebounceDelay());
+  buttonConfig.setDebounceDelay(1);
+  assertEqual((uint16_t)1, buttonConfig.getDebounceDelay());
 
-  adjustableConfig.setClickDelay(2);
-  assertEqual((uint16_t)2, adjustableConfig.getClickDelay());
+  buttonConfig.setClickDelay(2);
+  assertEqual((uint16_t)2, buttonConfig.getClickDelay());
 
-  adjustableConfig.setDoubleClickDelay(3);
-  assertEqual((uint16_t)3, adjustableConfig.getDoubleClickDelay());
+  buttonConfig.setDoubleClickDelay(3);
+  assertEqual((uint16_t)3, buttonConfig.getDoubleClickDelay());
 
-  adjustableConfig.setLongPressDelay(4);
-  assertEqual((uint16_t)4, adjustableConfig.getLongPressDelay());
+  buttonConfig.setLongPressDelay(4);
+  assertEqual((uint16_t)4, buttonConfig.getLongPressDelay());
 
-  adjustableConfig.setRepeatPressDelay(5);
-  assertEqual((uint16_t)5, adjustableConfig.getRepeatPressDelay());
+  buttonConfig.setRepeatPressDelay(5);
+  assertEqual((uint16_t)5, buttonConfig.getRepeatPressDelay());
 
-  adjustableConfig.setRepeatPressInterval(6);
-  assertEqual((uint16_t)6, adjustableConfig.getRepeatPressInterval());
+  buttonConfig.setRepeatPressInterval(6);
+  assertEqual((uint16_t)6, buttonConfig.getRepeatPressInterval());
 }
 
 // ------------------------------------------------------------------

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
             steps {
                 dir('AUniter') {
                     git url: 'https://github.com/bxparks/AUniter',
-                        branch: 'develop'
+                        branch: 'master'
                 }
                 dir('libraries/AUnit') {
                     git url: 'https://github.com/bxparks/AUnit',

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
             steps {
                 dir('AUniter') {
                     git url: 'https://github.com/bxparks/AUniter',
-                        branch: 'master'
+                        branch: 'develop'
                 }
                 dir('libraries/AUnit') {
                     git url: 'https://github.com/bxparks/AUnit',
@@ -32,31 +32,31 @@ pipeline {
         stage('Verify Examples') {
             steps {
                 sh "AUniter/tools/auniter.sh \
-                    --config libraries/AceButton/tests/auniter.conf \
+                    --config libraries/AceButton/tests/auniter.ini \
                     verify \
-                    --pref sketchbook.path=$WORKSPACE \
-                    --boards $BOARDS \
+                    --sketchbook=$WORKSPACE \
+                    $BOARDS \
                     libraries/AceButton/examples/*"
             }
         }
         stage('Verify Tests') {
             steps {
                 sh "AUniter/tools/auniter.sh \
-                    --config libraries/AceButton/tests/auniter.conf \
+                    --config libraries/AceButton/tests/auniter.ini \
                     verify \
-                    --pref sketchbook.path=$WORKSPACE \
-                    --boards $BOARDS \
+                    --sketchbook=$WORKSPACE \
+                    $BOARDS \
                     libraries/AceButton/tests/AceButtonTest"
             }
         }
         stage('Test') {
             steps {
                 sh "AUniter/tools/auniter.sh \
-                    --config libraries/AceButton/tests/auniter.conf \
+                    --config libraries/AceButton/tests/auniter.ini \
                     test \
-                    --skip_if_no_port \
-                    --pref sketchbook.path=$WORKSPACE \
-                    --boards $BOARDS \
+                    --skip_missing_port \
+                    --sketchbook=$WORKSPACE \
+                    $BOARDS \
                     libraries/AceButton/tests/AceButtonTest"
             }
         }

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -22,6 +22,11 @@ pipeline {
                     git url: 'https://github.com/bxparks/AUnit',
                         branch: 'develop'
                 }
+                dir('libraries/CapacitiveSensor') {
+                    git url:
+                          'https://github.com/PaulStoffregen/CapacitiveSensor',
+                        branch: 'master'
+                }
             }
         }
         stage('Verify Examples') {

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -31,28 +31,31 @@ pipeline {
         }
         stage('Verify Examples') {
             steps {
-                sh "AUniter/tools/auniter.sh --verify \
-                    --pref sketchbook.path=$WORKSPACE \
+                sh "AUniter/tools/auniter.sh \
                     --config libraries/AceButton/tests/auniter.conf \
+                    verify \
+                    --pref sketchbook.path=$WORKSPACE \
                     --boards $BOARDS \
                     libraries/AceButton/examples/*"
             }
         }
         stage('Verify Tests') {
             steps {
-                sh "AUniter/tools/auniter.sh --verify \
-                    --pref sketchbook.path=$WORKSPACE \
+                sh "AUniter/tools/auniter.sh \
                     --config libraries/AceButton/tests/auniter.conf \
+                    verify \
+                    --pref sketchbook.path=$WORKSPACE \
                     --boards $BOARDS \
                     libraries/AceButton/tests/AceButtonTest"
             }
         }
         stage('Test') {
             steps {
-                sh "AUniter/tools/auniter.sh --test \
+                sh "AUniter/tools/auniter.sh \
+                    --config libraries/AceButton/tests/auniter.conf \
+                    test \
                     --skip_if_no_port \
                     --pref sketchbook.path=$WORKSPACE \
-                    --config libraries/AceButton/tests/auniter.conf \
                     --boards $BOARDS \
                     libraries/AceButton/tests/AceButtonTest"
             }

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
                 sh "AUniter/tools/auniter.sh \
                     --config libraries/AceButton/tests/auniter.ini \
                     verify \
-                    --sketchbook=$WORKSPACE \
+                    --sketchbook $WORKSPACE \
                     $BOARDS \
                     libraries/AceButton/examples/*"
             }
@@ -44,7 +44,7 @@ pipeline {
                 sh "AUniter/tools/auniter.sh \
                     --config libraries/AceButton/tests/auniter.ini \
                     verify \
-                    --sketchbook=$WORKSPACE \
+                    --sketchbook $WORKSPACE \
                     $BOARDS \
                     libraries/AceButton/tests/AceButtonTest"
             }
@@ -55,7 +55,7 @@ pipeline {
                     --config libraries/AceButton/tests/auniter.ini \
                     test \
                     --skip_missing_port \
-                    --sketchbook=$WORKSPACE \
+                    --sketchbook $WORKSPACE \
                     $BOARDS \
                     libraries/AceButton/tests/AceButtonTest"
             }

--- a/tests/auniter.conf
+++ b/tests/auniter.conf
@@ -10,3 +10,5 @@
 # Options for each board
 [options]
   leonardo = --nolocking
+  esp8266 = --exclude CapacitiveButton
+  esp32 = --exclude CapacitiveButton

--- a/tests/auniter.ini
+++ b/tests/auniter.ini
@@ -7,8 +7,17 @@
   esp32 = espressif:esp32:esp32:PartitionScheme=default,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=none
   teensy32 = teensy:avr:teensy31:usb=serial,speed=96,opt=o2std,keys=en-us
 
-# Options for each board
-[options]
-  leonardo = --nolocking
-  esp8266 = --exclude CapacitiveButton
-  esp32 = --exclude CapacitiveButton
+[env:nano]
+  board = nano
+
+[env:esp8266]
+  board = esp8266
+  exclude = CapacitiveButton
+
+[env:esp32]
+  board = esp32
+  exclude = CapacitiveButton
+
+[env:leonardo]
+  board = leonardo
+  locking = false

--- a/tests/auniter.ini
+++ b/tests/auniter.ini
@@ -3,21 +3,23 @@
   uno = arduino:avr:uno
   nano = arduino:avr:nano:cpu=atmega328old
   leonardo = arduino:avr:leonardo
-  esp8266 = esp8266:esp8266:nodemcuv2:CpuFrequency=80,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=none,UploadSpeed=921600
+  nodemcuv2 = esp8266:esp8266:nodemcuv2:CpuFrequency=80,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=none,UploadSpeed=921600
   esp32 = espressif:esp32:esp32:PartitionScheme=default,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=none
-  teensy32 = teensy:avr:teensy31:usb=serial,speed=96,opt=o2std,keys=en-us
+
+[env:uno]
+  board = uno
 
 [env:nano]
   board = nano
 
+[env:leonardo]
+  board = leonardo
+  locking = false
+
 [env:esp8266]
-  board = esp8266
+  board = nodemcuv2
   exclude = CapacitiveButton
 
 [env:esp32]
   board = esp32
   exclude = CapacitiveButton
-
-[env:leonardo]
-  board = leonardo
-  locking = false


### PR DESCRIPTION
* 1.3 (2018-09-30)
    * Merge `AdjustableButtonConfig` into `ButtonConfig` and deprecated
      `AdjustableButtonConfig`. See
      [Issue #13](https://github.com/bxparks/AceButton/issues/13) for
      benchmarks which show that the theoretical increase of static RAM
      consumption does not often happen in practice because of compiler
      optimization.
    * Reduce default value of `getDebounceDelay()` from 50 ms to 20 ms
      to improve perceived responsiveness of buttons when they are rapidly
      pressed on and off. See
      [Issue #14](https://github.com/bxparks/AceButton/issues/14)
      for details.
    * Update `tests/auniter.ini` and `Jenkinsfile` for compatibility with
      AUniter v1.7. Add `CapacitiveSensor` to the exclude list for
      `env:esp8266` and `env:esp32` because it doesn't compile under those
      environments.
    * Remove leading zero in `ACE_BUTTON_VERSION` because that I forgot that it
      means an octal number.
