### PR TITLE
merge 1.10.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 * Unreleased
+* 1.10.1 (2023-05-25)
+    * Remove unnecessary declaration of `__FlashStringHelper` in `AceButton.h`.
+        * Breaks boards using the ArduinoCore-API, which moved the
+          `__FlashStringHelper` to the `arduino::` namespace, while polluting
+          the global namespace anyway with a `using
+          arduino::__FlashStringHelper` shim in an attempt to provide backwards
+          compatibility, which doesn't always work.
+        * See [Issue#120](https://github.com/bxparks/AceButton/issues/120).
 * 1.10.0 (2023-05-24)
     * Add `AceButton::eventName(event)` lookup function
         * Translates the event integer constant (e.g. `kEventDoubleClicked`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 * Unreleased
 * 1.10.0 (2023-05-24)
     * Add `AceButton::eventName(event)` lookup function
-        * Translates the event integer constant (e.g. `kEventDoublePressed`)
-          into a human readable string (e.g. "DoublePressed").
+        * Translates the event integer constant (e.g. `kEventDoubleClicked`)
+          into a human readable string (e.g. "DoubleClicked").
         * Intended for development and debugging.
     * Update supported boards and tiers
         * Add SAMD21 and SAMD51 boards to Tier 1

--- a/README.md
+++ b/README.md
@@ -2092,6 +2092,9 @@ insight. Here are some limitations and bugs.
     * See
       [Discussion#118](https://github.com/bxparks/AceButton/discussions/118)
       for info.
+    * An alternative solution might be to use the `kEventHeartBeat` and a custom
+      `IEventHandler` to generate a custom event. See
+      [examples/HeartBeat](examples/HeartBeat) for a example.
 * The [Event Supression](#EventSuppression) features are complicated, hard
   to understand and remember.
     * I wrote the code and I cannot remember how they all work. I have to

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ greater than the number of input pins available. This library provides
 Both `EncodedButtonConfig` and `LadderButtonConfig` support all events listed
 above (e.g. `kEventClicked` and `kEventDoubleClicked`).
 
-**Version**: 1.10.0 (2023-05-24)
+**Version**: 1.10.1 (2023-05-25)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AceButton
-version=1.10.0
+version=1.10.1
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=An adjustable, compact, event-driven button library that handles debouncing and dispatches events to a user-defined event handler.

--- a/src/AceButton.h
+++ b/src/AceButton.h
@@ -45,7 +45,7 @@ SOFTWARE.
 #include "ace_button/AceButton.h"
 
 // Version format: xxyyzz == "xx.yy.zz"
-#define ACE_BUTTON_VERSION 11000
-#define ACE_BUTTON_VERSION_STRING "1.10.0"
+#define ACE_BUTTON_VERSION 11001
+#define ACE_BUTTON_VERSION_STRING "1.10.1"
 
 #endif

--- a/src/ace_button/AceButton.h
+++ b/src/ace_button/AceButton.h
@@ -28,8 +28,6 @@ SOFTWARE.
 #include <Arduino.h>
 #include "ButtonConfig.h"
 
-class __FlashStringHelper;
-
 namespace ace_button {
 
 /**


### PR DESCRIPTION
* 1.10.1 (2023-05-25)
    * Remove unnecessary declaration of `__FlashStringHelper` in `AceButton.h`.
        * Breaks boards using the ArduinoCore-API, which moved the
          `__FlashStringHelper` to the `arduino::` namespace, while polluting
          the global namespace anyway with a `using
          arduino::__FlashStringHelper` shim in an attempt to provide backwards
          compatibility, which doesn't always work.
        * See [Issue#120](https://github.com/bxparks/AceButton/issues/120).